### PR TITLE
Support usage of relative urls to set database on the default host

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,15 @@ function parse(str) {
     return config;
   }
   config.host = result.hostname;
-  config.database = result.pathname ? decodeURI(result.pathname.slice(1)) : null;
+
+  // result.pathname is not always guaranteed to have a '/' prefix (e.g. relative urls)
+  // only strip the slash if it is present.
+  var pathname = result.pathname;
+  if (pathname && pathname.charAt(0) === '/') {
+    pathname = result.pathname.slice(1) || null;
+  }
+  config.database = pathname && decodeURI(pathname);
+
   var auth = (result.auth || ':').split(':');
   config.user = auth[0];
   config.password = auth[1];

--- a/test/parse.js
+++ b/test/parse.js
@@ -87,3 +87,26 @@ test('url is properly encoded', function(t){
   t.equal(subject.database, ' u%20rl');
   t.end();
 });
+
+test('relative url sets database', function(t){
+  var relative = 'different_db_on_default_host';
+  var subject = parse(relative);
+  t.equal(subject.database, 'different_db_on_default_host');
+  t.end();
+});
+
+test('no pathname returns null database', function (t) {
+  var subject = parse('pg://myhost');
+  t.equal(subject.host, 'myhost');
+  t.type(subject.database, 'null');
+
+  t.end();
+});
+
+test('pathname of "/" returns null database', function (t) {
+  var subject = parse('pg://myhost/');
+  t.equal(subject.host, 'myhost');
+  t.type(subject.database, 'null');
+
+  t.end();
+});


### PR DESCRIPTION
Ran into a real-world use-case in node-postgres where the host name was being set using an environment variable, but we needed to change the database in code.  node-postgres was being wrapped in other code that we could not edit for beurocratic reasons.  This code prevented us from passing config objects (i.e. forced us to pass a connection 'string').  The current code assumes that the pathname returned by nodejs will always have a leading '/'.  This is true for fully qualified urls, but NOT true for relative urls.  This caused pg-connection-string to return a database config object where the database was missing it's first character.  There are work-arounds, but it seems like something that is easily supported.

``` JavaScript
var pg = require('pg');

console.log(process.env.PGHOST); // '/tmp'
console.log(process.env.PGDATABASE); // 'default_db'

// this fails, as it tries to connect to 'yotherdb' after striping the first character.
pg.connect('my_other_db', function (err, client, done) {
});

//a hacky workaround.  Works because it strips the '.' and leaves the rest of the db.
pg.connect('.my_other_db', function (err, client, done) {
}); 
```
