### PR TITLE
Copy all but special-cased params from URL query string to config

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,13 +21,6 @@ function parse(str) {
   var result = url.parse(str, true);
   config = {};
 
-  if (result.query.application_name) {
-    config.application_name = result.query.application_name;
-  }
-  if (result.query.fallback_application_name) {
-    config.fallback_application_name = result.query.fallback_application_name;
-  }
-
   config.port = result.port;
   if(result.protocol == 'socket:') {
     config.host = decodeURI(result.pathname);
@@ -53,6 +46,18 @@ function parse(str) {
   if (ssl === 'true' || ssl === '1') {
     config.ssl = true;
   }
+
+  ['db', 'database', 'encoding', 'client_encoding', 'host', 'port', 'user', 'password', 'ssl']
+  .forEach(function(key) {
+    delete result.query[key];
+  });
+
+  Object.getOwnPropertyNames(result.query).forEach(function(key) {
+    var value = result.query[key];
+    if (Array.isArray(value))
+      value = value[value.length-1];
+    config[key] = value;
+  });
 
   return config;
 }

--- a/test/parse.js
+++ b/test/parse.js
@@ -124,3 +124,67 @@ test('pathname of "/" returns null database', function (t) {
 
   t.end();
 });
+
+test('configuration parameter application_name', function(t){
+  var connectionString = 'pg:///?application_name=TheApp';
+  var subject = parse(connectionString);
+  t.equal(subject.application_name, 'TheApp');
+  t.end();
+});
+
+test('configuration parameter fallback_application_name', function(t){
+  var connectionString = 'pg:///?fallback_application_name=TheAppFallback';
+  var subject = parse(connectionString);
+  t.equal(subject.fallback_application_name, 'TheAppFallback');
+  t.end();
+});
+
+test('configuration parameter fallback_application_name', function(t){
+  var connectionString = 'pg:///?fallback_application_name=TheAppFallback';
+  var subject = parse(connectionString);
+  t.equal(subject.fallback_application_name, 'TheAppFallback');
+  t.end();
+});
+
+test('configuration parameter ssl=true', function(t){
+  var connectionString = 'pg:///?ssl=true';
+  var subject = parse(connectionString);
+  t.equal(subject.ssl, true);
+  t.end();
+});
+
+test('configuration parameter ssl=1', function(t){
+  var connectionString = 'pg:///?ssl=1';
+  var subject = parse(connectionString);
+  t.equal(subject.ssl, true);
+  t.end();
+});
+
+test('configuration parameter keepalives', function(t){
+  var connectionString = 'pg:///?keepalives=1';
+  var subject = parse(connectionString);
+  t.equal(subject.keepalives, '1');
+  t.end();
+});
+
+test('unknown configuration parameter is passed into client', function(t){
+  var connectionString = 'pg:///?ThereIsNoSuchPostgresParameter=1234';
+  var subject = parse(connectionString);
+  t.equal(subject.ThereIsNoSuchPostgresParameter, '1234');
+  t.end();
+});
+
+test('do not override a config field with value from query string', function(t){
+  var subject = parse('socket:/some path/?db=my[db]&encoding=utf8&client_encoding=bogus');
+  t.equal(subject.host, '/some path/');
+  t.equal(subject.database, 'my[db]', 'must to be escaped and unescaped trough "my%5Bdb%5D"');
+  t.equal(subject.client_encoding, 'utf8');
+  t.end();
+});
+
+test('return last value of repeated parameter', function(t){
+  var connectionString = 'pg:///?keepalives=1&keepalives=0';
+  var subject = parse(connectionString);
+  t.equal(subject.keepalives, '0');
+  t.end();
+});


### PR DESCRIPTION
This semver-minor change is an alternative to whitelisting each individual Postgres parameter.

The "whitelist" approach can and does coexist with this change, in the special handling of `"ssl"`. In my view, future work can still add special handling for more params based on their types as listed in the Postgres docs, but clients must always also be able to deal with raw strings.
