### PR TITLE
Add support for Typescript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,14 @@
+export function parse(connectionString: string): ConnectionOptions;
+
+export interface ConnectionOptions {
+  host: string | null;
+  password: string | null;
+  user: string | null;
+  port: number | null;
+  database: string | null;
+  client_encoding: string | null;
+  ssl: boolean | null;
+
+  application_name: string | null;
+  fallback_application_name: string | null;
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "pg-connection-string",
   "version": "0.1.3",
   "description": "Functions for dealing with a PostgresSQL connection string",
-  "main": "index.js",
+  "main": "./index.js",
+  "types": "./index.d.ts",
   "scripts": {
     "test": "tap ./test"
   },


### PR DESCRIPTION
To allow Typescript applications to consume non-ts modules the right way, they must have typings, this PR add one.