### PR TITLE
Add support for TLS parameters in URI

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var url = require('url');
+var fs = require('fs');
 
 //Parse method copied from https://github.com/brianc/node-postgres
 //Copyright (c) 2010-2014 Brian Carlson (brian.m.carlson@gmail.com)
@@ -46,6 +47,22 @@ function parse(str) {
 
   if (config.ssl === 'true' || config.ssl === '1') {
     config.ssl = true;
+  }
+
+  if (config.sslcert || config.sslkey || config.sslrootcert) {
+    config.ssl = {};
+  }
+
+  if (config.sslcert) {
+    config.ssl.cert = fs.readFileSync(config.sslcert).toString();
+  }
+
+  if (config.sslkey) {
+    config.ssl.key = fs.readFileSync(config.sslkey).toString();
+  }
+
+  if (config.sslrootcert) {
+    config.ssl.ca = fs.readFileSync(config.sslrootcert).toString();
   }
 
   return config;

--- a/test/example.ca
+++ b/test/example.ca
@@ -1,0 +1,1 @@
+example ca

--- a/test/example.cert
+++ b/test/example.cert
@@ -1,0 +1,1 @@
+example cert

--- a/test/example.key
+++ b/test/example.key
@@ -1,0 +1,1 @@
+example key

--- a/test/parse.js
+++ b/test/parse.js
@@ -147,6 +147,30 @@ describe('parse', function(){
      subject.ssl.should.equal(true);
    });
 
+  it('configuration parameter sslcert=/path/to/cert', function(){
+    var connectionString = 'pg:///?sslcert=' + __dirname + '/example.cert';
+    var subject = parse(connectionString);
+    subject.ssl.should.eql({
+      cert: 'example cert\n'
+    });
+  });
+
+  it('configuration parameter sslkey=/path/to/key', function(){
+    var connectionString = 'pg:///?sslkey=' + __dirname + '/example.key';
+    var subject = parse(connectionString);
+    subject.ssl.should.eql({
+      key: 'example key\n'
+    });
+  });
+
+  it('configuration parameter sslrootcert=/path/to/ca', function(){
+    var connectionString = 'pg:///?sslrootcert=' + __dirname + '/example.ca';
+    var subject = parse(connectionString);
+    subject.ssl.should.eql({
+      ca: 'example ca\n'
+    });
+  });
+
    it('allow other params like max, ...', function () {
      var subject = parse('pg://myhost/db?max=18&min=4');
      subject.max.should.equal('18');


### PR DESCRIPTION
The connection string now supports the following parameters:

- sslcert
- sslkey
- sslrootcert

Fixes #25.